### PR TITLE
Add cbindgen as  dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 libc = "0.2"
 weggli = "0.2.4"
+
+[dev-dependencies]
+cbindgen = "0.21"


### PR DESCRIPTION
Add cbindgen as additional dependencies to avoid additional installation while integrating it with cmake. 