### PR TITLE
Export native library dependencies with staticlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT((CMAKE_BUILD_TYPE STREQUAL "Release") OR(CMAKE_BUILD_TYPE STREQUAL "Debug
     message(FATAL_ERROR "Only Debug and Release builds are supported")
 endif()
 
+include(cmake/utils.cmake)
+
 find_program(CARGO "cargo" REQUIRED)
 find_program(CBINDGEN "cbindgen" REQUIRED)
 
@@ -36,6 +38,8 @@ add_custom_target(build-all ALL
         "${CMAKE_BINARY_DIR}/${TARGET_DIR}/libweggli_native${CMAKE_STATIC_LIBRARY_SUFFIX}"
         "${CMAKE_BINARY_DIR}/${TARGET_DIR}/libweggli_native${CMAKE_SHARED_LIBRARY_SUFFIX}"
         "${CMAKE_BINARY_DIR}/weggli.h")
+
+find_native_staticlibs_dependencies(RUST_LINK_LIBRARIES)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,0 +1,31 @@
+
+# Utility function to get native library dependencies
+function(find_native_staticlibs_dependencies RUST_LINK_LIBRARIES_CACHED)
+  
+  if (DEFINED ${RUST_LINK_LIBRARIES_CACHED})
+    message(STATUS "Rust link libraries: ${RUST_LINK_LIBRARIES_CACHED}")
+    return()
+  endif()
+  
+  find_program(RUSTC "rustc" REQUIRED)
+  get_filename_component(RUSTC_NAME "${RUSTC}" NAME)
+  
+  execute_process(
+    COMMAND ${CARGO} ${RUSTC_NAME} -- --print=native-static-libs
+    OUTPUT_VARIABLE LINK_LIBRARIES_OUT
+    ERROR_VARIABLE LINK_LIBRARIES_ERR
+    RESULT_VARIABLE CORGO_RET
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
+  if (NOT "${CORGO_RET}" STREQUAL "0")
+    message(FATAL_ERROR "cargo build failed: ${LINK_LIBRARIES_ERR}")
+  endif()
+  
+  set(RUST_LINK_LIBRARIES "${LINK_LIBRARIES_OUT} ${LINK_LIBRARIES_ERR}")
+  string(REGEX MATCHALL "note: native-static-libs: ([\-a-zA-Z_0-9+ \.]+)" RUST_LINK_LIBRARIES "${RUST_LINK_LIBRARIES}")
+  string(REPLACE "note: native-static-libs: " "" RUST_LINK_LIBRARIES "${RUST_LINK_LIBRARIES}")
+  
+  message(STATUS "rust libraries: ${RUST_LINK_LIBRARIES}")
+  set(${RUST_LINK_LIBRARIES_CACHED} "${RUST_LINK_LIBRARIES}" CACHE STRING "Required link libraries by rust" FORCE)
+
+endfunction(find_native_staticlibs_dependencies)

--- a/cmake/weggli_native-config.cmake.in
+++ b/cmake/weggli_native-config.cmake.in
@@ -7,6 +7,7 @@ if(NOT TARGET weggli_native::static)
         IMPORTED_LOCATION "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/libweggli_native@CMAKE_STATIC_LIBRARY_SUFFIX@"
         PUBLIC_HEADER "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/weggli.h")
     target_include_directories(weggli_native::static INTERFACE "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@")
+    target_link_libraries(weggli_native::static INTERFACE "@RUST_LINK_LIBRARIES@")
 endif()
 
 if(NOT TARGET weggli_native::shared)


### PR DESCRIPTION
Export native library dependencies to fix the Multiplier build error on Linux. 